### PR TITLE
Add new `disableRequest` option to perform `fetch` with a bare URL

### DIFF
--- a/src/buildFullPath.test.ts
+++ b/src/buildFullPath.test.ts
@@ -4,4 +4,5 @@ test("URLs can be built from a combination of base URLs and relative URLs", () =
   expect(buildFullPath("http://example.com")).toBe("http://example.com");
   expect(buildFullPath("", "http://example.com")).toBe("http://example.com");
   expect(buildFullPath("/bar", "http://example.com/foo")).toBe("http://example.com/foo/bar");
+  expect(buildFullPath("/bar")).toBe("/bar");
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -169,6 +169,24 @@ test("Headers are passed to Axios", async () => {
   expect(result.request.headers.get("Content-Type")).toBe("application/json");
 });
 
+test("Default adapter throws for relative URLs with no base", async () => {
+  try {
+    await fetchAdapter({ url: "/bar" });
+    throw new Error("Invalid request didn't throw");
+  } catch (e: unknown) {
+    const error = e as TypeError;
+    expect(error.message).toBe("Failed to parse URL from /bar");
+  }
+});
+
+test("Can disable Request object creation for custom adapters", async () => {
+  const myFetch = async (_: RequestInfo | URL) => new Response("Custom fetch!");
+  const customAdapter = createFetchAdapter({ fetch: myFetch, disableRequest: true });
+  const result = await customAdapter({ url: "/bar" });
+  expect(result.request).toBe("/bar");
+  expect(result.status).toBe(200);
+});
+
 test("Invalid request will throw an error", async () => {
   // Disables fetch mock for the rest of this file
   jest.restoreAllMocks();


### PR DESCRIPTION
This PR allows passing the URL directly to the `fetch` function without creating a `Request` object first. With these changes, we don't get an `ERR_INVALID_URL` error when using non-fully-qualified URLs like `/foo`.

A side effect of the `disableRequest` option is that the `AxiosResponse` object will only have this URL in its `request` property. This means that accessing, for example, `response.request.url` will throw an error.