### PR TITLE
Treat `Set-Cookie` header as an array.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -106,9 +106,20 @@ async function getResponse(
     return createError("Network Error", config, "ERR_NETWORK", request);
   }
 
-  const stageOneHeaders: Record<string, string> = {};
+  const stageOneHeaders: Record<string, string | string[]> = {};
   stageOne.headers.forEach((value, key) => {
-    stageOneHeaders[key] = value;
+    // The `Set-Cookie` header is treated as an array of strings (even if there's only 1)
+    if (key === "set-cookie") {
+      const cookies = stageOneHeaders[key] as string[] | undefined
+
+      if (cookies) {
+        cookies.push(value);
+      } else {
+        stageOneHeaders[key] = [value];
+      }
+    } else {
+      stageOneHeaders[key] = value;
+    }
   });
   const headers: any = Object.assign({}, stageOneHeaders as unknown);
   const response: AxiosResponse = {


### PR DESCRIPTION
This package currently handles the `Set-Cookie` header like any other header, but `axios` actually treats this header as an array of strings. In the current implementation, user-code attempting to loop over each cookie actually loops over each character of the last cookie.

This pull request fixes the package to match the behavior of `axios`.

Related:

https://github.com/axios/axios/pull/5085

https://github.com/axios/axios/blob/a52e4d9af51205959ef924f87bcf90c605e08a1e/test/specs/helpers/parseHeaders.spec.js#L19-L32
https://github.com/axios/axios/blob/a52e4d9af51205959ef924f87bcf90c605e08a1e/lib/helpers/parseHeaders.js#L43-L48